### PR TITLE
Fix the broken "Integration guide" link

### DIFF
--- a/content/integrations/index.md
+++ b/content/integrations/index.md
@@ -1,6 +1,6 @@
 # Integrations
 
-Here is a list of Synthetix Integrations both on and offchain. For projects wishing to integate with Synthetix please see the technical [Integration guide](/integration-guide/)
+Here is a list of Synthetix Integrations both on and offchain. For projects wishing to integate with Synthetix please see the technical [Integration guide](/integration/guide/)
 
 ## The Graph
 


### PR DESCRIPTION
The "Integration guide" link on the Integrations page was pointing to /integration-guide/ (404 Not Found) while it should have been pointing to /integration/guide/.